### PR TITLE
refactor(increments-service): update routes and handlers for page views functionality

### DIFF
--- a/analytics-project/increments-service/constants/index.ts
+++ b/analytics-project/increments-service/constants/index.ts
@@ -1,0 +1,13 @@
+export const HTTP_STATUS = {
+  OK: 200,
+  BAD_REQUEST: 400,
+  INTERNAL_SERVER_ERROR: 500,
+} as const;
+
+export const ERROR_MESSAGES = {
+  INVALID_TIMESTAMP: "Invalid timestamp format",
+  INVALID_PAGE: "Invalid page identifier",
+  PAGE_INCREMENT_FAILED: "Failed to increment page views",
+  BATCH_INCREMENT_FAILED: "Failed to increment multiple pages",
+  INTERNAL_SERVER_ERROR: "Internal server error",
+} as const;

--- a/analytics-project/increments-service/handlers/index.ts
+++ b/analytics-project/increments-service/handlers/index.ts
@@ -2,12 +2,6 @@ import type { FastifyReply, FastifyRequest, FastifyInstance } from "fastify";
 import { logger } from "../index.ts";
 import { HTTP_STATUS, ERROR_MESSAGES } from "../constants/index.ts";
 
-type ValidationResult = {
-  isValid: boolean;
-  error?: string;
-  details?: string;
-};
-
 const singleIncrementSchema = {
   body: {
     type: "object",
@@ -23,12 +17,15 @@ const singleIncrementSchema = {
 const multiIncrementSchema = {
   body: {
     type: "object",
+    minProperties: 1,
     patternProperties: {
       "^.+$": {
         type: "object",
+        minProperties: 1,
         patternProperties: {
           "^.+$": { type: "number", minimum: 0 },
         },
+        additionalProperties: false,
       },
     },
     additionalProperties: false,
@@ -43,95 +40,12 @@ export type CreateOrUpdateMultiIncrementRequest = FastifyRequest<{
   Body: Record<string, Record<string, number>>;
 }>;
 
-function validateSingleIncrement(
-  page: string,
-  timestamp: string,
-): ValidationResult {
-  if (!page || typeof page !== "string" || page.trim().length === 0) {
-    return {
-      isValid: false,
-      error: ERROR_MESSAGES.INVALID_PAGE,
-      details: `Invalid page identifier: '${page}'. Page must be a non-empty string.`,
-    };
-  }
-
-  const date = new Date(timestamp);
-  if (isNaN(date.getTime())) {
-    return {
-      isValid: false,
-      error: ERROR_MESSAGES.INVALID_TIMESTAMP,
-      details: `Invalid timestamp format: '${timestamp}'. Expected ISO 8601 format.`,
-    };
-  }
-
-  return { isValid: true };
-}
-
-function validateMultipleIncrements(
-  pageData: Record<string, Record<string, number>>,
-): ValidationResult {
-  if (!pageData || typeof pageData !== "object") {
-    return {
-      isValid: false,
-      error: "Invalid input data",
-      details: "Invalid page data: expected object with page names as keys",
-    };
-  }
-
-  for (const [page, timeData] of Object.entries(pageData)) {
-    if (!page || typeof page !== "string" || page.trim().length === 0) {
-      return {
-        isValid: false,
-        error: "Invalid input data",
-        details: `Invalid page identifier: '${page}'. Page must be a non-empty string.`,
-      };
-    }
-
-    if (!timeData || typeof timeData !== "object") {
-      return {
-        isValid: false,
-        error: "Invalid input data",
-        details: `Invalid time data for page '${page}': expected object with timestamps as keys.`,
-      };
-    }
-
-    for (const [timeKey, value] of Object.entries(timeData)) {
-      const date = new Date(timeKey);
-      if (isNaN(date.getTime())) {
-        return {
-          isValid: false,
-          error: "Invalid input data",
-          details: `Invalid timestamp format for page '${page}' at time '${timeKey}': expected ISO 8601 format.`,
-        };
-      }
-
-      if (typeof value !== "number" || value < 0 || !Number.isInteger(value)) {
-        return {
-          isValid: false,
-          error: "Invalid input data",
-          details: `Invalid increment value for page '${page}' at time '${timeKey}': expected non-negative integer, got ${value}.`,
-        };
-      }
-    }
-  }
-
-  return { isValid: true };
-}
-
 export async function createOrUpdateSingleIncrementHandler(
   request: CreateOrUpdateSingleIncrementRequest,
   reply: FastifyReply,
 ) {
   try {
     const { page, timestamp } = request.body;
-
-    const validation = validateSingleIncrement(page, timestamp);
-    if (!validation.isValid) {
-      return reply.status(HTTP_STATUS.BAD_REQUEST).send({
-        error: validation.error,
-        details: validation.details,
-      });
-    }
 
     await request.server.incrementsService.incrementPage(page, timestamp);
     return reply.status(HTTP_STATUS.OK).send();
@@ -165,12 +79,22 @@ export async function createOrUpdateMultiIncrementHandler(
       });
     }
 
-    const validation = validateMultipleIncrements(pageData);
-    if (!validation.isValid) {
-      return reply.status(HTTP_STATUS.BAD_REQUEST).send({
-        error: validation.error,
-        details: validation.details,
-      });
+    for (const [page, timeData] of Object.entries(pageData)) {
+      if (!page || page.trim().length === 0) {
+        return reply.status(HTTP_STATUS.BAD_REQUEST).send({
+          error: "Request body cannot be empty",
+        });
+      }
+
+      for (const [timeKey] of Object.entries(timeData)) {
+        const date = new Date(timeKey);
+        if (isNaN(date.getTime())) {
+          return reply.status(HTTP_STATUS.BAD_REQUEST).send({
+            error: "Invalid input data",
+            details: `Invalid timestamp format for page '${page}' at time '${timeKey}': expected ISO 8601 format.`,
+          });
+        }
+      }
     }
 
     await request.server.incrementsService.incrementMultiplePages(pageData);

--- a/analytics-project/increments-service/handlers/index.ts
+++ b/analytics-project/increments-service/handlers/index.ts
@@ -5,6 +5,10 @@ export type CreateOrUpdateSingleIncrementRequest = FastifyRequest<{
   Body: { page: string; timestamp: string };
 }>;
 
+export type CreateOrUpdateMultiIncrementRequest = FastifyRequest<{
+  Body: Record<string, Record<string, number>>;
+}>;
+
 export async function createOrUpdateSingleIncrementHandler(
   request: CreateOrUpdateSingleIncrementRequest,
   reply: FastifyReply,
@@ -13,6 +17,7 @@ export async function createOrUpdateSingleIncrementHandler(
     const { page, timestamp } = request.body;
 
     await request.server.incrementsService.incrementPage(page, timestamp);
+    return reply.status(200).send({ success: true });
   } catch (err) {
     if (err instanceof Error) {
       logger.error({
@@ -26,6 +31,28 @@ export async function createOrUpdateSingleIncrementHandler(
   }
 }
 
+export async function createOrUpdateMultiIncrementHandler(
+  request: CreateOrUpdateMultiIncrementRequest,
+  reply: FastifyReply,
+) {
+  try {
+    const pageData = request.body;
+
+    await request.server.incrementsService.incrementMultiplePages(pageData);
+    return reply.status(200).send({ success: true });
+  } catch (err) {
+    if (err instanceof Error) {
+      logger.error({
+        action: "INCREMENT MULTIPLE PAGES",
+        message: err.message,
+        cause: err.cause,
+      });
+    }
+
+    return reply.status(500).send("Couldn't increment multiple pages");
+  }
+}
+
 export async function incrementsRoutes(
   fastify: FastifyInstance,
   options: object,
@@ -33,5 +60,9 @@ export async function incrementsRoutes(
   fastify.post<{ Body: { page: string; timestamp: string } }>(
     "/single",
     createOrUpdateSingleIncrementHandler,
+  );
+  fastify.post<{ Body: Record<string, Record<string, number>> }>(
+    "/multi",
+    createOrUpdateMultiIncrementHandler,
   );
 }

--- a/analytics-project/increments-service/handlers/index.ts
+++ b/analytics-project/increments-service/handlers/index.ts
@@ -1,5 +1,39 @@
 import type { FastifyReply, FastifyRequest, FastifyInstance } from "fastify";
 import { logger } from "../index.ts";
+import { HTTP_STATUS, ERROR_MESSAGES } from "../constants/index.ts";
+
+type ValidationResult = {
+  isValid: boolean;
+  error?: string;
+  details?: string;
+};
+
+const singleIncrementSchema = {
+  body: {
+    type: "object",
+    required: ["page", "timestamp"],
+    properties: {
+      page: { type: "string", minLength: 1, maxLength: 255 },
+      timestamp: { type: "string", format: "date-time" },
+    },
+    additionalProperties: false,
+  },
+};
+
+const multiIncrementSchema = {
+  body: {
+    type: "object",
+    patternProperties: {
+      "^.+$": {
+        type: "object",
+        patternProperties: {
+          "^.+$": { type: "number", minimum: 0 },
+        },
+      },
+    },
+    additionalProperties: false,
+  },
+};
 
 export type CreateOrUpdateSingleIncrementRequest = FastifyRequest<{
   Body: { page: string; timestamp: string };
@@ -9,6 +43,81 @@ export type CreateOrUpdateMultiIncrementRequest = FastifyRequest<{
   Body: Record<string, Record<string, number>>;
 }>;
 
+function validateSingleIncrement(
+  page: string,
+  timestamp: string,
+): ValidationResult {
+  if (!page || typeof page !== "string" || page.trim().length === 0) {
+    return {
+      isValid: false,
+      error: ERROR_MESSAGES.INVALID_PAGE,
+      details: `Invalid page identifier: '${page}'. Page must be a non-empty string.`,
+    };
+  }
+
+  const date = new Date(timestamp);
+  if (isNaN(date.getTime())) {
+    return {
+      isValid: false,
+      error: ERROR_MESSAGES.INVALID_TIMESTAMP,
+      details: `Invalid timestamp format: '${timestamp}'. Expected ISO 8601 format.`,
+    };
+  }
+
+  return { isValid: true };
+}
+
+function validateMultipleIncrements(
+  pageData: Record<string, Record<string, number>>,
+): ValidationResult {
+  if (!pageData || typeof pageData !== "object") {
+    return {
+      isValid: false,
+      error: "Invalid input data",
+      details: "Invalid page data: expected object with page names as keys",
+    };
+  }
+
+  for (const [page, timeData] of Object.entries(pageData)) {
+    if (!page || typeof page !== "string" || page.trim().length === 0) {
+      return {
+        isValid: false,
+        error: "Invalid input data",
+        details: `Invalid page identifier: '${page}'. Page must be a non-empty string.`,
+      };
+    }
+
+    if (!timeData || typeof timeData !== "object") {
+      return {
+        isValid: false,
+        error: "Invalid input data",
+        details: `Invalid time data for page '${page}': expected object with timestamps as keys.`,
+      };
+    }
+
+    for (const [timeKey, value] of Object.entries(timeData)) {
+      const date = new Date(timeKey);
+      if (isNaN(date.getTime())) {
+        return {
+          isValid: false,
+          error: "Invalid input data",
+          details: `Invalid timestamp format for page '${page}' at time '${timeKey}': expected ISO 8601 format.`,
+        };
+      }
+
+      if (typeof value !== "number" || value < 0 || !Number.isInteger(value)) {
+        return {
+          isValid: false,
+          error: "Invalid input data",
+          details: `Invalid increment value for page '${page}' at time '${timeKey}': expected non-negative integer, got ${value}.`,
+        };
+      }
+    }
+  }
+
+  return { isValid: true };
+}
+
 export async function createOrUpdateSingleIncrementHandler(
   request: CreateOrUpdateSingleIncrementRequest,
   reply: FastifyReply,
@@ -16,18 +125,30 @@ export async function createOrUpdateSingleIncrementHandler(
   try {
     const { page, timestamp } = request.body;
 
+    const validation = validateSingleIncrement(page, timestamp);
+    if (!validation.isValid) {
+      return reply.status(HTTP_STATUS.BAD_REQUEST).send({
+        error: validation.error,
+        details: validation.details,
+      });
+    }
+
     await request.server.incrementsService.incrementPage(page, timestamp);
-    return reply.status(200).send({ success: true });
+    return reply.status(HTTP_STATUS.OK).send();
   } catch (err) {
     if (err instanceof Error) {
       logger.error({
         action: "INCREMENT PAGE",
         message: err.message,
         cause: err.cause,
+        page: request.body.page,
+        timestamp: request.body.timestamp,
       });
     }
 
-    return reply.status(500).send("Couldn't increment page");
+    return reply.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send({
+      error: ERROR_MESSAGES.PAGE_INCREMENT_FAILED,
+    });
   }
 }
 
@@ -38,18 +159,35 @@ export async function createOrUpdateMultiIncrementHandler(
   try {
     const pageData = request.body;
 
+    if (!pageData || Object.keys(pageData).length === 0) {
+      return reply.status(HTTP_STATUS.BAD_REQUEST).send({
+        error: "Request body cannot be empty",
+      });
+    }
+
+    const validation = validateMultipleIncrements(pageData);
+    if (!validation.isValid) {
+      return reply.status(HTTP_STATUS.BAD_REQUEST).send({
+        error: validation.error,
+        details: validation.details,
+      });
+    }
+
     await request.server.incrementsService.incrementMultiplePages(pageData);
-    return reply.status(200).send({ success: true });
+    return reply.status(HTTP_STATUS.OK).send();
   } catch (err) {
     if (err instanceof Error) {
       logger.error({
         action: "INCREMENT MULTIPLE PAGES",
         message: err.message,
         cause: err.cause,
+        pageCount: Object.keys(request.body).length,
       });
     }
 
-    return reply.status(500).send("Couldn't increment multiple pages");
+    return reply.status(HTTP_STATUS.INTERNAL_SERVER_ERROR).send({
+      error: ERROR_MESSAGES.BATCH_INCREMENT_FAILED,
+    });
   }
 }
 
@@ -59,10 +197,13 @@ export async function incrementsRoutes(
 ) {
   fastify.post<{ Body: { page: string; timestamp: string } }>(
     "/single",
+    { schema: singleIncrementSchema },
     createOrUpdateSingleIncrementHandler,
   );
+
   fastify.post<{ Body: Record<string, Record<string, number>> }>(
     "/multi",
+    { schema: multiIncrementSchema },
     createOrUpdateMultiIncrementHandler,
   );
 }

--- a/analytics-project/increments-service/index.ts
+++ b/analytics-project/increments-service/index.ts
@@ -24,7 +24,7 @@ const start = async () => {
       new IncrementsService(fastify.incrementsRepository),
     );
 
-    await fastify.register(incrementsRoutes, { prefix: "/increments" });
+    await fastify.register(incrementsRoutes, { prefix: "/page-views" });
 
     await fastify.listen({ port: config.PORT, host: "0.0.0.0" });
     logger.info(`Server listening on port ${config.PORT}`);

--- a/analytics-project/increments-service/integration.test.ts
+++ b/analytics-project/increments-service/integration.test.ts
@@ -3,7 +3,6 @@ import { type FastifyInstance } from "fastify";
 import { Pool } from "pg";
 import { createTestApp } from "./test-setup.ts";
 import { uuidv7 } from "uuidv7";
-import { logger } from "./index.ts";
 
 vi.mock("./logger/index.ts", () => ({
   createLogger: () => ({
@@ -54,7 +53,10 @@ describe("Increments Service API Integration Tests", () => {
       );
 
       expect(result.rows.length).toBe(1);
-      expect(result.rows[0].views_count).toBe("1");
+      expect(result.rows[0]).toMatchObject({
+        name: incrementData.page,
+        views_count: "1",
+      });
     });
 
     it("should update existing page_views when creating with same page", async () => {
@@ -63,7 +65,6 @@ describe("Increments Service API Integration Tests", () => {
         timestamp: "2025-01-01T00:00:00.000Z",
       };
 
-      // Create page_views first
       await app.inject({
         method: "POST",
         url: "/page-views/single",
@@ -84,7 +85,52 @@ describe("Increments Service API Integration Tests", () => {
       );
 
       expect(result.rows.length).toBe(1);
-      expect(result.rows[0].views_count).toBe("2");
+      expect(result.rows[0]).toMatchObject({
+        name: incrementData.page,
+        views_count: "2",
+      });
+    });
+
+    it("should handle invalid timestamp format", async () => {
+      const incrementData = {
+        page: "test.html",
+        timestamp: "invalid-timestamp",
+      };
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/page-views/single",
+        payload: incrementData,
+      });
+
+      expect(response.statusCode).toBe(400);
+      const responseBody = JSON.parse(response.body);
+      expect(responseBody).toMatchObject({
+        error: "Bad Request",
+      });
+      expect(responseBody.message).toContain("date-time");
+    });
+
+    it("should handle empty page identifier", async () => {
+      const incrementData = {
+        page: "",
+        timestamp: "2025-01-01T00:00:00.000Z",
+      };
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/page-views/single",
+        payload: incrementData,
+      });
+
+      expect(response.statusCode).toBe(400);
+      const responseBody = JSON.parse(response.body);
+      expect(responseBody).toMatchObject({
+        error: "Bad Request",
+      });
+      expect(responseBody.message).toContain(
+        "must NOT have fewer than 1 characters",
+      );
     });
   });
 
@@ -110,33 +156,48 @@ describe("Increments Service API Integration Tests", () => {
 
       expect(response.statusCode).toBe(200);
 
-      // Check first page entries
       const altmanPage = Object.keys(multiIncrementData)[0];
       const altmanResult = await testPool.query(
         "SELECT * FROM page_views WHERE name = $1 ORDER BY hour",
         [altmanPage],
       );
 
-      expect(altmanResult.rows.length).toBe(3);
-      expect(altmanResult.rows[0].views_count).toBe("103");
-      expect(altmanResult.rows[0].hour).toBe(0);
-      expect(altmanResult.rows[1].views_count).toBe("200");
-      expect(altmanResult.rows[1].hour).toBe(1);
-      expect(altmanResult.rows[2].views_count).toBe("405");
-      expect(altmanResult.rows[2].hour).toBe(2);
+      expect(altmanResult.rows).toStrictEqual([
+        expect.objectContaining({
+          name: altmanPage,
+          views_count: "103",
+          hour: 0,
+        }),
+        expect.objectContaining({
+          name: altmanPage,
+          views_count: "200",
+          hour: 1,
+        }),
+        expect.objectContaining({
+          name: altmanPage,
+          views_count: "405",
+          hour: 2,
+        }),
+      ]);
 
-      // Check second page entries
       const muskPage = Object.keys(multiIncrementData)[1];
       const muskResult = await testPool.query(
         "SELECT * FROM page_views WHERE name = $1 ORDER BY hour",
         [muskPage],
       );
 
-      expect(muskResult.rows.length).toBe(2);
-      expect(muskResult.rows[0].views_count).toBe("838");
-      expect(muskResult.rows[0].hour).toBe(0);
-      expect(muskResult.rows[1].views_count).toBe("654");
-      expect(muskResult.rows[1].hour).toBe(1);
+      expect(muskResult.rows).toStrictEqual([
+        expect.objectContaining({
+          name: muskPage,
+          views_count: "838",
+          hour: 0,
+        }),
+        expect.objectContaining({
+          name: muskPage,
+          views_count: "654",
+          hour: 1,
+        }),
+      ]);
     });
 
     it("should update existing page_views when creating with same page and time", async () => {
@@ -147,14 +208,12 @@ describe("Increments Service API Integration Tests", () => {
         },
       };
 
-      // Create initial entry
       await app.inject({
         method: "POST",
         url: "/page-views/multi",
         payload: multiIncrementData,
       });
 
-      // Update with additional views
       const updateData = {
         [pageName]: {
           "2025-01-01T00:00:00.000Z": 50,
@@ -174,11 +233,13 @@ describe("Increments Service API Integration Tests", () => {
         [pageName],
       );
 
-      expect(result.rows.length).toBe(1);
-      expect(result.rows[0].views_count).toBe("150"); // 100 + 50
+      expect(result.rows[0]).toMatchObject({
+        name: pageName,
+        views_count: "150",
+      });
     });
 
-    it("should handle invalid time format", async () => {
+    it("should handle invalid timestamp format", async () => {
       const multiIncrementData = {
         "test.html": {
           "invalid-time-format": 100,
@@ -191,19 +252,78 @@ describe("Increments Service API Integration Tests", () => {
         payload: multiIncrementData,
       });
 
-      expect(response.statusCode).toBe(500);
+      expect(response.statusCode).toBe(400);
+      const responseBody = JSON.parse(response.body);
+      expect(responseBody).toMatchObject({
+        error: "Invalid input data",
+        details: expect.stringContaining("invalid-time-format"),
+      });
+    });
+
+    it("should handle empty request body", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/page-views/multi",
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      const responseBody = JSON.parse(response.body);
+      expect(responseBody).toStrictEqual({
+        error: "Request body cannot be empty",
+      });
+    });
+
+    it("should handle invalid page identifier", async () => {
+      const multiIncrementData = {
+        "": {
+          "2025-01-01T00:00:00.000Z": 100,
+        },
+      };
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/page-views/multi",
+        payload: multiIncrementData,
+      });
+
+      expect(response.statusCode).toBe(400);
+      const responseBody = JSON.parse(response.body);
+      expect(responseBody).toStrictEqual({
+        error: "Request body cannot be empty",
+      });
+    });
+
+    it("should handle negative increment values", async () => {
+      const multiIncrementData = {
+        "test.html": {
+          "2025-01-01T00:00:00.000Z": -5,
+        },
+      };
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/page-views/multi",
+        payload: multiIncrementData,
+      });
+
+      expect(response.statusCode).toBe(400);
+      const responseBody = JSON.parse(response.body);
+      expect(responseBody).toMatchObject({
+        error: "Bad Request",
+      });
+      expect(responseBody.message).toContain("must be >= 0");
     });
 
     it("should aggregate multiple entries for same page, date, and hour within single request", async () => {
       const pageName = `${uuidv7()}_aggregation_test.html`;
 
-      // Create data with multiple timestamps that resolve to the same hour
       const multiIncrementData = {
         [pageName]: {
-          "2025-01-01T00:15:00.000Z": 100, // Hour 0
-          "2025-01-01T00:30:00.000Z": 200, // Hour 0 (same hour as above)
-          "2025-01-01T00:45:00.000Z": 300, // Hour 0 (same hour as above)
-          "2025-01-01T01:00:00.000Z": 150, // Hour 1
+          "2025-01-01T00:15:00.000Z": 100,
+          "2025-01-01T00:30:00.000Z": 200,
+          "2025-01-01T00:45:00.000Z": 300,
+          "2025-01-01T01:00:00.000Z": 150,
         },
       };
 
@@ -220,16 +340,18 @@ describe("Increments Service API Integration Tests", () => {
         [pageName],
       );
 
-      // Should have 2 entries: one for hour 0 and one for hour 1
-      expect(result.rows.length).toBe(2);
-
-      // Hour 0 should have aggregated value: 100 + 200 + 300 = 600
-      expect(result.rows[0].hour).toBe(0);
-      expect(result.rows[0].views_count).toBe("600");
-
-      // Hour 1 should have the single value: 150
-      expect(result.rows[1].hour).toBe(1);
-      expect(result.rows[1].views_count).toBe("150");
+      expect(result.rows).toStrictEqual([
+        expect.objectContaining({
+          name: pageName,
+          hour: 0,
+          views_count: "600",
+        }),
+        expect.objectContaining({
+          name: pageName,
+          hour: 1,
+          views_count: "150",
+        }),
+      ]);
     });
   });
 });

--- a/analytics-project/increments-service/integration.test.ts
+++ b/analytics-project/increments-service/integration.test.ts
@@ -268,10 +268,6 @@ describe("Increments Service API Integration Tests", () => {
       });
 
       expect(response.statusCode).toBe(400);
-      const responseBody = JSON.parse(response.body);
-      expect(responseBody).toStrictEqual({
-        error: "Request body cannot be empty",
-      });
     });
 
     it("should handle invalid page identifier", async () => {

--- a/analytics-project/increments-service/integration.test.ts
+++ b/analytics-project/increments-service/integration.test.ts
@@ -33,7 +33,7 @@ describe("Increments Service API Integration Tests", () => {
     await testPool.end();
   });
 
-  describe("POST /increments/single", () => {
+  describe("POST /page-views/single", () => {
     it("should create a new page_views successfully", async () => {
       const incrementData = {
         page: `${uuidv7()}_altman.html`,
@@ -42,7 +42,7 @@ describe("Increments Service API Integration Tests", () => {
 
       const response = await app.inject({
         method: "POST",
-        url: "/increments/single",
+        url: "/page-views/single",
         payload: incrementData,
       });
 
@@ -66,13 +66,13 @@ describe("Increments Service API Integration Tests", () => {
       // Create page_views first
       await app.inject({
         method: "POST",
-        url: "/increments/single",
+        url: "/page-views/single",
         payload: incrementData,
       });
 
       const response = await app.inject({
         method: "POST",
-        url: "/increments/single",
+        url: "/page-views/single",
         payload: incrementData,
       });
 
@@ -85,6 +85,151 @@ describe("Increments Service API Integration Tests", () => {
 
       expect(result.rows.length).toBe(1);
       expect(result.rows[0].views_count).toBe("2");
+    });
+  });
+
+  describe("POST /page-views/multi", () => {
+    it("should create multiple page_views successfully", async () => {
+      const multiIncrementData = {
+        [`${uuidv7()}_altman.html`]: {
+          "2025-01-01T00:00:00.000Z": 103,
+          "2025-01-01T01:00:00.000Z": 200,
+          "2025-01-01T02:00:00.000Z": 405,
+        },
+        [`${uuidv7()}_musk.html`]: {
+          "2025-01-01T00:00:00.000Z": 838,
+          "2025-01-01T01:00:00.000Z": 654,
+        },
+      };
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/page-views/multi",
+        payload: multiIncrementData,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      // Check first page entries
+      const altmanPage = Object.keys(multiIncrementData)[0];
+      const altmanResult = await testPool.query(
+        "SELECT * FROM page_views WHERE name = $1 ORDER BY hour",
+        [altmanPage],
+      );
+
+      expect(altmanResult.rows.length).toBe(3);
+      expect(altmanResult.rows[0].views_count).toBe("103");
+      expect(altmanResult.rows[0].hour).toBe(0);
+      expect(altmanResult.rows[1].views_count).toBe("200");
+      expect(altmanResult.rows[1].hour).toBe(1);
+      expect(altmanResult.rows[2].views_count).toBe("405");
+      expect(altmanResult.rows[2].hour).toBe(2);
+
+      // Check second page entries
+      const muskPage = Object.keys(multiIncrementData)[1];
+      const muskResult = await testPool.query(
+        "SELECT * FROM page_views WHERE name = $1 ORDER BY hour",
+        [muskPage],
+      );
+
+      expect(muskResult.rows.length).toBe(2);
+      expect(muskResult.rows[0].views_count).toBe("838");
+      expect(muskResult.rows[0].hour).toBe(0);
+      expect(muskResult.rows[1].views_count).toBe("654");
+      expect(muskResult.rows[1].hour).toBe(1);
+    });
+
+    it("should update existing page_views when creating with same page and time", async () => {
+      const pageName = `${uuidv7()}_test.html`;
+      const multiIncrementData = {
+        [pageName]: {
+          "2025-01-01T00:00:00.000Z": 100,
+        },
+      };
+
+      // Create initial entry
+      await app.inject({
+        method: "POST",
+        url: "/page-views/multi",
+        payload: multiIncrementData,
+      });
+
+      // Update with additional views
+      const updateData = {
+        [pageName]: {
+          "2025-01-01T00:00:00.000Z": 50,
+        },
+      };
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/page-views/multi",
+        payload: updateData,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = await testPool.query(
+        "SELECT * FROM page_views WHERE name = $1",
+        [pageName],
+      );
+
+      expect(result.rows.length).toBe(1);
+      expect(result.rows[0].views_count).toBe("150"); // 100 + 50
+    });
+
+    it("should handle invalid time format", async () => {
+      const multiIncrementData = {
+        "test.html": {
+          "invalid-time-format": 100,
+        },
+      };
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/page-views/multi",
+        payload: multiIncrementData,
+      });
+
+      expect(response.statusCode).toBe(500);
+    });
+
+    it("should aggregate multiple entries for same page, date, and hour within single request", async () => {
+      const pageName = `${uuidv7()}_aggregation_test.html`;
+
+      // Create data with multiple timestamps that resolve to the same hour
+      const multiIncrementData = {
+        [pageName]: {
+          "2025-01-01T00:15:00.000Z": 100, // Hour 0
+          "2025-01-01T00:30:00.000Z": 200, // Hour 0 (same hour as above)
+          "2025-01-01T00:45:00.000Z": 300, // Hour 0 (same hour as above)
+          "2025-01-01T01:00:00.000Z": 150, // Hour 1
+        },
+      };
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/page-views/multi",
+        payload: multiIncrementData,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const result = await testPool.query(
+        "SELECT * FROM page_views WHERE name = $1 ORDER BY hour",
+        [pageName],
+      );
+
+      // Should have 2 entries: one for hour 0 and one for hour 1
+      expect(result.rows.length).toBe(2);
+
+      // Hour 0 should have aggregated value: 100 + 200 + 300 = 600
+      expect(result.rows[0].hour).toBe(0);
+      expect(result.rows[0].views_count).toBe("600");
+
+      // Hour 1 should have the single value: 150
+      expect(result.rows[1].hour).toBe(1);
+      expect(result.rows[1].views_count).toBe("150");
     });
   });
 });

--- a/analytics-project/increments-service/repositories/increments.ts
+++ b/analytics-project/increments-service/repositories/increments.ts
@@ -20,17 +20,33 @@ export class IncrementsRepository {
     };
   }
 
+  async #executeIncrementQuery(
+    session: any,
+    page: string,
+    date: Date,
+    hour: number,
+    value: number,
+  ) {
+    return await session.query(
+      `INSERT INTO page_views (id, name, date, hour, views_count) 
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (name, date, hour) 
+       DO UPDATE SET views_count = page_views.views_count + $5`,
+      [uuidv7(), page, date, hour, value],
+    );
+  }
+
   async incrementPage(page: string, date: Date, hour: number, value: number) {
     await using sessionResource = await this.#getSession();
     const { session } = sessionResource;
 
     try {
-      const result = await session.query(
-        `INSERT INTO page_views (id, name, date, hour, views_count) 
-         VALUES ($1, $2, $3, $4, $5)
-         ON CONFLICT (name, date, hour) 
-         DO UPDATE SET views_count = page_views.views_count + $5`,
-        [uuidv7(), page, date, hour, value],
+      const result = await this.#executeIncrementQuery(
+        session,
+        page,
+        date,
+        hour,
+        value,
       );
 
       if (result.rowCount === 0) {
@@ -45,5 +61,138 @@ export class IncrementsRepository {
     } catch (err) {
       throw new Error("Couldn't increment page", { cause: err });
     }
+  }
+
+  async incrementMultiplePages(
+    pageIncrements: Array<{
+      page: string;
+      date: Date;
+      hour: number;
+      value: number;
+    }>,
+  ) {
+    if (pageIncrements.length === 0) {
+      return {
+        successful: [],
+        failed: [],
+        totalProcessed: 0,
+        successCount: 0,
+        errorCount: 0,
+      };
+    }
+
+    await using sessionResource = await this.#getSession();
+    const { session } = sessionResource;
+
+    try {
+      const values = [];
+      const placeholders = [];
+      let paramIndex = 1;
+
+      for (const increment of pageIncrements) {
+        values.push(
+          uuidv7(),
+          increment.page,
+          increment.date,
+          increment.hour,
+          increment.value,
+        );
+        placeholders.push(
+          `($${paramIndex}, $${paramIndex + 1}, $${paramIndex + 2}, $${paramIndex + 3}, $${paramIndex + 4})`,
+        );
+        paramIndex += 5;
+      }
+
+      const sql = `
+        INSERT INTO page_views (id, name, date, hour, views_count) 
+        VALUES ${placeholders.join(", ")}
+        ON CONFLICT (name, date, hour) 
+        DO UPDATE SET views_count = page_views.views_count + EXCLUDED.views_count
+      `;
+
+      await session.query(sql, values);
+
+      const successfulResults = pageIncrements.map((increment) => ({
+        page: increment.page,
+        date: increment.date,
+        hour: increment.hour,
+        success: true,
+      }));
+
+      return {
+        successful: successfulResults,
+        failed: [],
+        totalProcessed: pageIncrements.length,
+        successCount: pageIncrements.length,
+        errorCount: 0,
+      };
+    } catch (err) {
+      logger.error({
+        action: "INCREMENT MULTIPLE PAGES",
+        message: "Failed to increment pages in batch",
+        cause: { count: pageIncrements.length, error: err },
+      });
+
+      // Fallback to individual processing if batch fails
+      return await this.#incrementPagesIndividually(pageIncrements);
+    }
+  }
+
+  async #incrementPagesIndividually(
+    pageIncrements: Array<{
+      page: string;
+      date: Date;
+      hour: number;
+      value: number;
+    }>,
+  ) {
+    await using sessionResource = await this.#getSession();
+    const { session } = sessionResource;
+
+    const results = [];
+    const errors = [];
+
+    for (const increment of pageIncrements) {
+      try {
+        const result = await this.#executeIncrementQuery(
+          session,
+          increment.page,
+          increment.date,
+          increment.hour,
+          increment.value,
+        );
+        results.push({
+          page: increment.page,
+          date: increment.date,
+          hour: increment.hour,
+          success: true,
+        });
+      } catch (err) {
+        errors.push({
+          page: increment.page,
+          date: increment.date,
+          hour: increment.hour,
+          error: err,
+        });
+        logger.warn({
+          action: "INCREMENT MULTIPLE PAGES",
+          message: "Failed to increment page",
+          cause: {
+            page: increment.page,
+            date: increment.date,
+            hour: increment.hour,
+            error: err,
+          },
+        });
+      }
+    }
+
+    return {
+      successful: results,
+      failed: errors,
+      totalProcessed: pageIncrements.length,
+      successCount: results.length,
+      errorCount: errors.length,
+    };
   }
 }

--- a/analytics-project/increments-service/repositories/increments.ts
+++ b/analytics-project/increments-service/repositories/increments.ts
@@ -1,4 +1,4 @@
-import { Pool } from "pg";
+import { Pool, type PoolClient } from "pg";
 import { pool } from "./pool.ts";
 import { logger } from "../index.ts";
 import { uuidv7 } from "uuidv7";
@@ -21,7 +21,7 @@ export class IncrementsRepository {
   }
 
   async #executeIncrementQuery(
-    session: any,
+    session: PoolClient,
     page: string,
     date: Date,
     hour: number,

--- a/analytics-project/increments-service/services/increments.service.ts
+++ b/analytics-project/increments-service/services/increments.service.ts
@@ -3,23 +3,31 @@ import type { IncrementsRepository } from "../repositories/increments.ts";
 export class IncrementsService {
   constructor(private readonly incrementsRepository: IncrementsRepository) {}
 
-  async incrementPage(page: string, timestamp: string) {
+  async incrementPage(page: string, timestamp: string): Promise<void> {
     const date = new Date(timestamp);
     const hour = date.getUTCHours();
     const value = 1;
 
-    const dateOnly = date.toISOString().split("T")[0];
-    const dateOnlyObj = new Date(dateOnly + "T00:00:00.000Z");
-
     await this.incrementsRepository.incrementPage(
-      page,
-      dateOnlyObj,
+      page.trim(),
+      date,
       hour,
       value,
     );
   }
 
   async incrementMultiplePages(
+    pageData: Record<string, Record<string, number>>,
+  ): Promise<void> {
+    const increments = this.parsePageIncrements(pageData);
+    const groupedIncrements = this.groupIncrements(increments);
+
+    await this.incrementsRepository.incrementMultiplePages(
+      Object.values(groupedIncrements),
+    );
+  }
+
+  private parsePageIncrements(
     pageData: Record<string, Record<string, number>>,
   ) {
     const increments: Array<{
@@ -32,17 +40,10 @@ export class IncrementsService {
     for (const [page, timeData] of Object.entries(pageData)) {
       for (const [timeKey, value] of Object.entries(timeData)) {
         const date = new Date(timeKey);
-
-        if (isNaN(date.getTime())) {
-          throw new Error(
-            `Invalid time format: ${timeKey}. Expected format: ISO 8601 timestamp`,
-          );
-        }
-
         const hour = date.getUTCHours();
 
         increments.push({
-          page,
+          page: page.trim(),
           date,
           hour,
           value,
@@ -50,26 +51,32 @@ export class IncrementsService {
       }
     }
 
+    return increments;
+  }
+
+  private groupIncrements(
+    increments: Array<{
+      page: string;
+      date: Date;
+      hour: number;
+      value: number;
+    }>,
+  ) {
     const groupedIncrements = increments.reduce(
       (acc, increment) => {
-        const dateOnly = increment.date.toISOString().split("T")[0];
-        const key = `${increment.page}-${dateOnly}-${increment.hour}`;
+        const dateKey = increment.date.toISOString().split("T")[0];
+        const key = `${increment.page}:${dateKey}:${increment.hour}`;
+
         if (acc[key]) {
           acc[key].value += increment.value;
         } else {
-          const dateOnlyObj = new Date(dateOnly + "T00:00:00.000Z");
-          acc[key] = {
-            ...increment,
-            date: dateOnlyObj,
-          };
+          acc[key] = increment;
         }
         return acc;
       },
       {} as Record<string, (typeof increments)[number]>,
     );
 
-    await this.incrementsRepository.incrementMultiplePages(
-      Object.values(groupedIncrements),
-    );
+    return groupedIncrements;
   }
 }

--- a/analytics-project/increments-service/services/increments.service.ts
+++ b/analytics-project/increments-service/services/increments.service.ts
@@ -5,9 +5,71 @@ export class IncrementsService {
 
   async incrementPage(page: string, timestamp: string) {
     const date = new Date(timestamp);
-    const hour = date.getHours();
+    const hour = date.getUTCHours();
     const value = 1;
 
-    await this.incrementsRepository.incrementPage(page, date, hour, value);
+    const dateOnly = date.toISOString().split("T")[0];
+    const dateOnlyObj = new Date(dateOnly + "T00:00:00.000Z");
+
+    await this.incrementsRepository.incrementPage(
+      page,
+      dateOnlyObj,
+      hour,
+      value,
+    );
+  }
+
+  async incrementMultiplePages(
+    pageData: Record<string, Record<string, number>>,
+  ) {
+    const increments: Array<{
+      page: string;
+      date: Date;
+      hour: number;
+      value: number;
+    }> = [];
+
+    for (const [page, timeData] of Object.entries(pageData)) {
+      for (const [timeKey, value] of Object.entries(timeData)) {
+        const date = new Date(timeKey);
+
+        if (isNaN(date.getTime())) {
+          throw new Error(
+            `Invalid time format: ${timeKey}. Expected format: ISO 8601 timestamp`,
+          );
+        }
+
+        const hour = date.getUTCHours();
+
+        increments.push({
+          page,
+          date,
+          hour,
+          value,
+        });
+      }
+    }
+
+    const groupedIncrements = increments.reduce(
+      (acc, increment) => {
+        const dateOnly = increment.date.toISOString().split("T")[0];
+        const key = `${increment.page}-${dateOnly}-${increment.hour}`;
+        if (acc[key]) {
+          acc[key].value += increment.value;
+        } else {
+          const dateOnlyObj = new Date(dateOnly + "T00:00:00.000Z");
+          acc[key] = {
+            ...increment,
+            date: dateOnlyObj,
+          };
+        }
+        return acc;
+      },
+      {} as Record<string, (typeof increments)[number]>,
+    );
+
+    await this.incrementsRepository.incrementMultiplePages(
+      Object.values(groupedIncrements),
+    );
   }
 }

--- a/analytics-project/increments-service/test-setup.ts
+++ b/analytics-project/increments-service/test-setup.ts
@@ -26,7 +26,7 @@ export async function createTestApp(): Promise<{
   }
 
   execSync(
-    `flyway -url=jdbc:postgresql://localhost:54321/analytics -user=postgres -password=postgres -locations=filesystem:${__dirname}/migrations migrate`,
+    `flyway -url=jdbc:postgresql://localhost:54321/analytics -user=postgres -password=postgres -locations=filesystem:${__dirname}/../migrations migrate`,
   );
 
   const app = Fastify({ logger: false });
@@ -37,7 +37,7 @@ export async function createTestApp(): Promise<{
   app.decorate("incrementsRepository", incrementsRepository);
   app.decorate("incrementsService", incrementsService);
 
-  await app.register(incrementsRoutes, { prefix: "/increments" });
+  await app.register(incrementsRoutes, { prefix: "/page-views" });
   await app.ready();
 
   return { app, testPool };


### PR DESCRIPTION


- Change route prefix from "/increments" to "/page-views" in the service and tests
- Implement new handler for batch increment requests with "/multi" endpoint
- Update existing increment logic to support multiple page views in a single request
- Adjust integration tests to reflect new endpoint structure and functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to support batch creation and updating of multiple page views in a single request.
* **Bug Fixes**
  * Improved error handling for invalid timestamp formats in batch operations.
* **Refactor**
  * All date and time handling for page views now use UTC for consistency.
  * The route prefix for page view endpoints has changed from "/increments" to "/page-views".
* **Tests**
  * Added integration tests for the new batch page views endpoint, including edge cases and aggregation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->